### PR TITLE
Small Fixes

### DIFF
--- a/src/components/astro/ThemeToggle.astro
+++ b/src/components/astro/ThemeToggle.astro
@@ -4,7 +4,7 @@
   id="theme-toggle"
   title="toggles light and dark theme"
   aria-label="auto"
-  aria-alive="polite"
+  aria-live="polite"
 >
   <svg
     class="sun-and-moon w-full h-full"

--- a/src/components/react/HeaderNav/DesktopHeaderNav.tsx
+++ b/src/components/react/HeaderNav/DesktopHeaderNav.tsx
@@ -22,7 +22,7 @@ export function DesktopHeaderNav() {
 
           return (
             <NavigationMenu.Item key={el.label}>
-              <NavigationMenu.Trigger className="hover:bg-zinc-700 focus:shadow-zinc-200 group flex select-none items-center justify-between gap-[2px] rounded-md px-3 py-2 uppercase font-medium leading-none outline-none focus:shadow-[0_0_0_2px] -translate-y-[2px]">
+              <NavigationMenu.Trigger className="hover:bg-zinc-700 focus:shadow-zinc-200 group flex select-none items-center justify-between gap-[2px] rounded-md px-3 pr-1 py-2 uppercase font-medium leading-none outline-none focus:shadow-[0_0_0_2px] -translate-y-[2px]">
                 {el.label}{" "}
                 <ChevronDown
                   size={20}


### PR DESCRIPTION
1. header items with arrow padding right a little less than before
2. typo fix: `aria-alive` to `aria-live`